### PR TITLE
Update apt-install to use cython3 name

### DIFF
--- a/ubuntu_2204/README.md
+++ b/ubuntu_2204/README.md
@@ -2,7 +2,7 @@ Install many ros packages and dependencies of ros packages that will be built fr
 
 
 ```
-sudo apt install ros-* catkin-lint cython libapriltag-dev libceres-dev libfrei0r-ocaml-dev libgeographic-dev libgmock-dev libgoogle-glog-dev libgst-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev python-is-python3 python3-tf2-geometry-msgs python3-venv vim curl jq
+sudo apt install ros-* catkin-lint cython3 libapriltag-dev libceres-dev libfrei0r-ocaml-dev libgeographic-dev libgmock-dev libgoogle-glog-dev libgst-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev python-is-python3 python3-tf2-geometry-msgs python3-venv vim curl jq
 ```
 
 Put this into ~/.bashrc so that vcs and catkin_tools can be found (TODO(lucasw) make them install to ~/.local/... instead like pip user installs?)


### PR DESCRIPTION
cython was renamed cython3 in the Jammy 22.04 repositories