### PR TITLE
Robot state publisher, rtabmap, plotjuggler updates

### DIFF
--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -161,6 +161,12 @@ jobs:
           cd ..
           catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -Wno-deprecated
 
+      - name: build rtabmap_ros
+        run: |
+          cd base_catkin_ws
+          catkin build --no-status rtabmap_ros
+          source devel/setup.bash
+
       - name: build joint_trajectory_controller
         run: |
           cd base_catkin_ws

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -158,8 +158,8 @@ jobs:
       - name: build fiducials
         run: |
           cd install_base_catkin_ws
-          source install/setup.bash
           catkin build --no-status fiducials
+          source install/setup.bash
 
       ### BASE DEVEL BUILD ###
       - name: setup base_catkin_ws

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -245,19 +245,19 @@ jobs:
 
       ### BASE INSTALL BUILD ###
 
-      - name: build joint_trajectory_controller
+      - name: build install joint_trajectory_controller
         run: |
           cd install_base_catkin_ws
           catkin build --no-status joint_trajectory_controller
           source install/setup.bash
 
-      - name: test joint_trajectory_controller
+      - name: test install joint_trajectory_controller
         run: |
           cd install_base_catkin_ws
           source install/setup.bash
           catkin test --no-status joint_trajectory_controller
 
-      - name: build plotjuggler
+      - name: build install plotjuggler
         run: |
           cd install_base_catkin_ws
           source install/setup.bash
@@ -265,25 +265,25 @@ jobs:
           source install/setup.bash
           catkin build --no-status plotjuggler_ros
 
-      - name: build jsk_common_msgs
+      - name: build install jsk_common_msgs
         run: |
           cd install_base_catkin_ws
           source install/setup.bash
           catkin build --no-status jsk_common_msgs
 
-      - name: build rviz
+      - name: build install rviz
         run: |
           cd install_base_catkin_ws
           source install/setup.bash
           catkin build --no-status rviz
 
-      - name: build jsk_rviz_plugins
+      - name: build install jsk_rviz_plugins
         run: |
           cd install_base_catkin_ws
           source install/setup.bash
           catkin build --no-status jsk_rviz_plugins
 
-      - name: build fuse
+      - name: build install fuse
         run: |
           cd install_base_catkin_ws
           source install/setup.bash

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -162,6 +162,12 @@ jobs:
           cd ..
           catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -Wno-deprecated
 
+      - name: build fiducials
+        run: |
+          cd base_catkin_ws
+          catkin build --no-status fiducials
+          source devel/setup.bash
+
       - name: build qt_gui_core
         run: |
           cd base_catkin_ws

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -4,8 +4,17 @@ on:
   push:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ubuntu2204:
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [install, devel]
+
     runs-on: ubuntu-22.04
     # env:
     steps:
@@ -147,160 +156,113 @@ jobs:
           which catkin
           catkin --version
 
-      ### BASE DEVEL BUILD ###
       - name: setup base_catkin_ws
         run: |
-          mkdir -p base_catkin_ws/src
-          cd base_catkin_ws/src
+          mkdir -p ${{ matrix.build_type }}_base_catkin_ws/src
+          cd ${{ matrix.build_type }}_base_catkin_ws/src
           ln -s ../../other/src/ros_from_src/ubuntu_2204/base_repos.yaml
           # need https instead of git@github
           sed -i 's/git@github.com:/https:\/\/github.com\//' base_repos.yaml
+          ls -l
           vcs import --shallow < base_repos.yaml
           # ignore repos that aren't yet building in 22.04
           ../../other/src/ros_from_src/ubuntu_2204/ignore.sh
 
-          cd ..
+      - name: devel setup
+        if: ${{ matrix.build_type == 'devel' }}
+        run: |
+          cd ${{ matrix.build_type }}_base_catkin_ws
           catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -Wno-deprecated
 
-      ### trying early install build
-      - name: setup base_catkin_ws
+      - name: install setup
+        if: ${{ matrix.build_type == 'install' }}
         run: |
-          mkdir install_base_catkin_ws
-          cd install_base_catkin_ws
-          ln -s ../base_catkin_ws/src
+          cd ${{ matrix.build_type }}_base_catkin_ws
           catkin config --install --cmake-args -DCMAKE_BUILD_TYPE=Release -Wno-deprecated
-
-      - name: build fiducials
-        run: |
-          cd install_base_catkin_ws
-          catkin build --no-status fiducials
-          source install/setup.bash
 
       # back to devel build
       - name: build fiducials
         run: |
-          cd base_catkin_ws
+          cd ${{ matrix.build_type }}_base_catkin_ws
           catkin build --no-status fiducials
-          source devel/setup.bash
+          source ${{ matrix.build_type }}/setup.bash
 
       - name: build qt_gui_core
         run: |
-          cd base_catkin_ws
+          cd ${{ matrix.build_type }}_base_catkin_ws
           catkin build --no-status qt_gui_core
-          source devel/setup.bash
+          source ${{ matrix.build_type }}/setup.bash
 
       - name: build rtabmap_ros
         run: |
-          cd base_catkin_ws
+          cd ${{ matrix.build_type }}_base_catkin_ws
           catkin build --no-status rtabmap_ros
-          source devel/setup.bash
+          source ${{ matrix.build_type }}/setup.bash
 
       - name: build joint_trajectory_controller
         run: |
-          cd base_catkin_ws
+          cd ${{ matrix.build_type }}_base_catkin_ws
           catkin build --no-status joint_trajectory_controller
-          source devel/setup.bash
+          source ${{ matrix.build_type }}/setup.bash
 
       - name: test joint_trajectory_controller
+        if: ${{ matrix.build_type == 'devel' }}
         run: |
-          cd base_catkin_ws
-          source devel/setup.bash
+          cd ${{ matrix.build_type }}_base_catkin_ws
+          source ${{ matrix.build_type }}/setup.bash
           catkin build joint_trajectory_controller --no-status --no-deps --catkin-make-args tests
           rostest joint_trajectory_controller joint_trajectory_controller.test
           # catkin test --no-status joint_trajectory_controller
 
+      - name: test install joint_trajectory_controller
+        if: ${{ matrix.build_type == 'install' }}
+        run: |
+          cd ${{ matrix.build_type }}_base_catkin_ws
+          source ${{ matrix.build_type }}/setup.bash
+          catkin test --no-status joint_trajectory_controller
+
       - name: build plotjuggler
         run: |
-          cd base_catkin_ws
-          source devel/setup.bash
+          cd ${{ matrix.build_type }}_base_catkin_ws
+          source ${{ matrix.build_type }}/setup.bash
           # Does building plotjuggler before plotjuggler_ros mess up in install?
           # catkin build --no-status plotjuggler
           catkin build --no-status plotjuggler_ros
-          source devel/setup.bash
+          source ${{ matrix.build_type }}/setup.bash
 
       - name: build rviz
         run: |
-          cd base_catkin_ws
-          source devel/setup.bash
+          cd ${{ matrix.build_type }}_base_catkin_ws
+          source ${{ matrix.build_type }}/setup.bash
           catkin build --no-status rviz
-          source devel/setup.bash
+          source ${{ matrix.build_type }}/setup.bash
 
       - name: build jsk_rviz_plugins
         run: |
-          cd base_catkin_ws
-          source devel/setup.bash
+          cd ${{ matrix.build_type }}_base_catkin_ws
+          source ${{ matrix.build_type }}/setup.bash
           catkin build --no-status jsk_rviz_plugins
 
       - name: build fuse
         run: |
-          cd base_catkin_ws
-          source devel/setup.bash
+          cd ${{ matrix.build_type }}_base_catkin_ws
+          source ${{ matrix.build_type }}/setup.bash
           catkin build --no-status fuse_models fuse_optimizers
 
-      - name: build rest of base_catkin_ws
+      - name: build rest of ${{ matrix.build_type }}_base_catkin_ws
         run: |
-          cd base_catkin_ws
-          source devel/setup.bash
-          catkin build --no-status
-
-      ### BASE INSTALL BUILD ###
-
-      - name: build install joint_trajectory_controller
-        run: |
-          cd install_base_catkin_ws
-          catkin build --no-status joint_trajectory_controller
-          source install/setup.bash
-
-      - name: test install joint_trajectory_controller
-        run: |
-          cd install_base_catkin_ws
-          source install/setup.bash
-          catkin test --no-status joint_trajectory_controller
-
-      - name: build install plotjuggler
-        run: |
-          cd install_base_catkin_ws
-          source install/setup.bash
-          catkin build --no-status plotjuggler
-          source install/setup.bash
-          catkin build --no-status plotjuggler_ros
-
-      - name: build install jsk_common_msgs
-        run: |
-          cd install_base_catkin_ws
-          source install/setup.bash
-          catkin build --no-status jsk_common_msgs
-
-      - name: build install rviz
-        run: |
-          cd install_base_catkin_ws
-          source install/setup.bash
-          catkin build --no-status rviz
-
-      - name: build install jsk_rviz_plugins
-        run: |
-          cd install_base_catkin_ws
-          source install/setup.bash
-          catkin build --no-status jsk_rviz_plugins
-
-      - name: build install fuse
-        run: |
-          cd install_base_catkin_ws
-          source install/setup.bash
-          catkin build --no-status fuse_models fuse_optimizers
-
-      - name: build and install rest of base packages
-        run: |
-          cd install_base_catkin_ws
-          source install/setup.bash
+          cd ${{ matrix.build_type }}_base_catkin_ws
+          source ${{ matrix.build_type }}/setup.bash
           catkin build --no-status
 
       - name: tar up install_catkin_ws
+        if: ${{ matrix.build_type == 'install' }}
         run: |
-          tar cvzf install_catkin_ws_2204.tgz install_base_catkin_ws/install
+          tar cvzf install_catkin_ws_2204.tgz ${{ matrix.build_type }}_base_catkin_ws/install
           ls -l
 
       - name: update install_catkin_ws_2204.tgz
+        if: ${{ matrix.build_type == 'install' }}
         uses: actions/upload-artifact@v2
         with:
           name: install_catkin_ws_2204

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -187,23 +187,29 @@ jobs:
           catkin build --no-status fiducials
           source ${{ matrix.build_type }}/setup.bash
 
+      - name: build grid_map
+        run: |
+          cd ${{ matrix.build_type }}_base_catkin_ws
+          source ${{ matrix.build_type }}/setup.bash
+          catkin build --no-status grid_map*
+
       - name: build qt_gui_core
         run: |
           cd ${{ matrix.build_type }}_base_catkin_ws
-          catkin build --no-status qt_gui_core
           source ${{ matrix.build_type }}/setup.bash
+          catkin build --no-status qt_gui_core
 
       - name: build rtabmap_ros
         run: |
           cd ${{ matrix.build_type }}_base_catkin_ws
-          catkin build --no-status rtabmap_ros
           source ${{ matrix.build_type }}/setup.bash
+          catkin build --no-status rtabmap_ros
 
       - name: build joint_trajectory_controller
         run: |
           cd ${{ matrix.build_type }}_base_catkin_ws
-          catkin build --no-status joint_trajectory_controller
           source ${{ matrix.build_type }}/setup.bash
+          catkin build --no-status joint_trajectory_controller
 
       - name: test joint_trajectory_controller
         if: ${{ matrix.build_type == 'devel' }}
@@ -237,11 +243,11 @@ jobs:
           catkin build --no-status rviz
           source ${{ matrix.build_type }}/setup.bash
 
-      - name: build jsk_rviz_plugins
+      - name: build jsk
         run: |
           cd ${{ matrix.build_type }}_base_catkin_ws
           source ${{ matrix.build_type }}/setup.bash
-          catkin build --no-status jsk_rviz_plugins
+          catkin build --no-status jsk*
 
       - name: build fuse
         run: |

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -55,6 +55,7 @@ jobs:
           sudo apt-get install -yqq libyaml-cpp-dev
           sudo apt-get install -yqq cython3
           sudo apt-get install -yqq libapriltag-dev
+          sudo apt-get install -yqq libfmt-dev
           sudo apt-get install -yqq libzmq3-dev
 
       - name: apt sdl installs

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -147,20 +147,6 @@ jobs:
           which catkin
           catkin --version
 
-      ### trying early install build
-      - name: setup base_catkin_ws
-        run: |
-          mkdir install_base_catkin_ws
-          cd install_base_catkin_ws
-          ln -s ../base_catkin_ws/src
-          catkin config --install --cmake-args -DCMAKE_BUILD_TYPE=Release -Wno-deprecated
-
-      - name: build fiducials
-        run: |
-          cd install_base_catkin_ws
-          catkin build --no-status fiducials
-          source install/setup.bash
-
       ### BASE DEVEL BUILD ###
       - name: setup base_catkin_ws
         run: |
@@ -176,6 +162,21 @@ jobs:
           cd ..
           catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -Wno-deprecated
 
+      ### trying early install build
+      - name: setup base_catkin_ws
+        run: |
+          mkdir install_base_catkin_ws
+          cd install_base_catkin_ws
+          ln -s ../base_catkin_ws/src
+          catkin config --install --cmake-args -DCMAKE_BUILD_TYPE=Release -Wno-deprecated
+
+      - name: build fiducials
+        run: |
+          cd install_base_catkin_ws
+          catkin build --no-status fiducials
+          source install/setup.bash
+
+      # back to devel build
       - name: build fiducials
         run: |
           cd base_catkin_ws

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -162,6 +162,12 @@ jobs:
           cd ..
           catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -Wno-deprecated
 
+      - name: build qt_gui_core
+        run: |
+          cd base_catkin_ws
+          catkin build --no-status qt_gui_core
+          source devel/setup.bash
+
       - name: build rtabmap_ros
         run: |
           cd base_catkin_ws

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -147,6 +147,20 @@ jobs:
           which catkin
           catkin --version
 
+      ### trying early install build
+      - name: setup base_catkin_ws
+        run: |
+          mkdir install_base_catkin_ws
+          cd install_base_catkin_ws
+          ln -s ../base_catkin_ws/src
+          catkin config --install --cmake-args -DCMAKE_BUILD_TYPE=Release -Wno-deprecated
+
+      - name: build fiducials
+        run: |
+          cd install_base_catkin_ws
+          source install/setup.bash
+          catkin build --no-status fiducials
+
       ### BASE DEVEL BUILD ###
       - name: setup base_catkin_ws
         run: |
@@ -229,12 +243,6 @@ jobs:
           catkin build --no-status
 
       ### BASE INSTALL BUILD ###
-      - name: setup base_catkin_ws
-        run: |
-          mkdir install_base_catkin_ws
-          cd install_base_catkin_ws
-          ln -s ../base_catkin_ws/src
-          catkin config --install --cmake-args -DCMAKE_BUILD_TYPE=Release -Wno-deprecated
 
       - name: build joint_trajectory_controller
         run: |
@@ -280,7 +288,7 @@ jobs:
           source install/setup.bash
           catkin build --no-status fuse_models fuse_optimizers
 
-      - name: build rest of base packages
+      - name: build and install rest of base packages
         run: |
           cd install_base_catkin_ws
           source install/setup.bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y apt-utils
 # apt installs
 # TODO(lucasw) used to do these on separate layers but github actions has a layer limit?
 # it was failing later with 'ERROR: failed to solve: failed to prepare...max depth exceeded'
-RUN apt-get install -y build-essential bzip2 libbz2-dev cmake git libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-regex-dev libboost-thread-dev libgpgme-dev libgtest-dev liblog4cxx-dev liblz4-dev lz4 libpoco-dev libtinyxml2-dev mawk coreutils python-is-python3 python3 python3-dev python3-empy python3-setuptools python3-yaml
+RUN apt-get install -y build-essential bzip2 libbz2-dev cmake git libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-regex-dev libboost-thread-dev libfmt-dev libgpgme-dev libgtest-dev liblog4cxx-dev liblz4-dev lz4 libpoco-dev libtinyxml2-dev mawk coreutils python-is-python3 python3 python3-dev python3-empy python3-setuptools python3-yaml
 
 ENV SRC=/src
 RUN mkdir $SRC -p

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,28 +12,9 @@ RUN apt-get update
 RUN apt-get install -y apt-utils
 
 # apt installs
-RUN apt-get install -y build-essential
-RUN apt-get install -y bzip2 libbz2-dev
-RUN apt-get install -y cmake
-RUN apt-get install -y git
-RUN apt-get install -y libboost-dev
-RUN apt-get install -y libboost-filesystem-dev
-RUN apt-get install -y libboost-program-options-dev
-RUN apt-get install -y libboost-regex-dev
-RUN apt-get install -y libboost-thread-dev
-RUN apt-get install -y libgpgme-dev
-RUN apt-get install -y libgtest-dev
-RUN apt-get install -y liblog4cxx-dev
-RUN apt-get install -y liblz4-dev lz4
-RUN apt-get install -y libpoco-dev
-RUN apt-get install -y libtinyxml2-dev
-RUN apt-get install -y mawk coreutils
-RUN apt-get install -y python-is-python3
-RUN apt-get install -y python3
-RUN apt-get install -y python3-dev
-RUN apt-get install -y python3-empy
-RUN apt-get install -y python3-setuptools
-RUN apt-get install -y python3-yaml
+# TODO(lucasw) used to do these on separate layers but github actions has a layer limit?
+# it was failing later with 'ERROR: failed to solve: failed to prepare...max depth exceeded'
+RUN apt-get install -y build-essential bzip2 libbz2-dev cmake git libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-regex-dev libboost-thread-dev libgpgme-dev libgtest-dev liblog4cxx-dev liblz4-dev lz4 libpoco-dev libtinyxml2-dev mawk coreutils python-is-python3 python3 python3-dev python3-empy python3-setuptools python3-yaml
 
 ENV SRC=/src
 RUN mkdir $SRC -p
@@ -241,7 +222,7 @@ RUN catkin build
 # rospack list won't work by itself
 RUN source devel/setup.bash && rospack list
 
-RUN apt install python3-netifaces
+RUN apt-get install python3-netifaces
 
 WORKDIR $WS/..
 # TODO(lucasw) run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,24 +25,18 @@ RUN mkdir $WS -p
 
 ENV DEST=/opt/ros/noetic
 
+# TODO(lucasw) this doesn't work in 20.04 because of log
+# --build-args ROSCONSOLE=https://github.com/ros-o/rosconsole
+ARG ROSCONSOLE=https://github.com/ros-o/rosconsole
+# ENV ROSCONSOLE=$ROSCONSOLE
+RUN echo $ROSCONSOLE
+
 # packages that need to be cmake installed, and are ros packages in a catkin workspace
-WORKDIR $WS
-RUN git clone https://github.com/ros/catkin
-RUN git clone https://github.com/ros/console_bridge
-RUN git clone https://github.com/ros/cmake_modules
-RUN git clone https://github.com/ros-o/class_loader
-RUN git clone https://github.com/ros/rospack
-RUN git clone https://github.com/ros/genmsg
-RUN git clone https://github.com/ros/ros
-
-# pure python
-WORKDIR $SRC
-RUN git clone https://github.com/ros-infrastructure/catkin_pkg
-RUN git clone https://github.com/osrf/osrf_pycommon
-RUN git clone https://github.com/catkin/catkin_tools
-
-# cmake installs
-RUN git clone https://github.com/ros-o/ros_environment
+RUN mkdir $SRC/ros_from_src -p
+WORKDIR /
+COPY git_clone.sh $SRC/ros_from_src
+# WORKDIR $SRC/ros_from_src
+RUN ROS_CONSOLE=$ROSCONSOLE $SRC/ros_from_src/git_clone.sh
 
 # python installs
 
@@ -61,6 +55,7 @@ RUN echo $PYTHONPATH
 
 # catkin_pkg
 WORKDIR $SRC/catkin_pkg
+RUN pwd
 RUN python3 setup.py install --prefix=$DEST --record install_manifest.txt --single-version-externally-managed
 RUN ls -l $OPT_PYTHONPATH
 RUN ls -l $OPT_PYTHONPATH/catkin_pkg
@@ -160,41 +155,17 @@ RUN apt-get install -y python3-distro
 
 # ros packages, regular catkin build only for these
 WORKDIR $WS
-RUN git clone https://github.com/ros/ros_comm
-RUN git clone https://github.com/ros/roscpp_core
-RUN git clone https://github.com/ros/ros_comm_msgs
-RUN git clone https://github.com/ros/message_generation
-RUN git clone https://github.com/ros/gencpp
-RUN git clone https://github.com/jsk-ros-pkg/geneus
-RUN git clone https://github.com/RethinkRobotics-opensource/gennodejs
-RUN git clone https://github.com/ros/genlisp
-RUN git clone https://github.com/ros/genpy
-RUN git clone https://github.com/ros/std_msgs
-RUN git clone https://github.com/ros/message_runtime
-RUN git clone https://github.com/ros-o/pluginlib
 
-# TODO(lucasw) this doesn't work in 20.04 because of log
-# --build-args ROSCONSOLE=https://github.com/ros-o/rosconsole
-ARG ROSCONSOLE=https://github.com/ros-o/rosconsole
-# ENV ROSCONSOLE=$ROSCONSOLE
-RUN echo $ROSCONSOLE
-RUN git clone $ROSCONSOLE
 
 # runtime dependencies
 # rosbuild
-WORKDIR $SRC
-RUN git clone https://github.com/ros/rospkg
 WORKDIR $SRC/rospkg
 RUN python3 setup.py install --prefix=$DEST --record install_manifest.txt --single-version-externally-managed
 
-WORKDIR $SRC
-RUN git clone https://github.com/ros-infrastructure/rosdistro
 WORKDIR $SRC/rosdistro
 RUN python3 setup.py install --prefix=$DEST --record install_manifest.txt --single-version-externally-managed
 
-WORKDIR $SRC
 # can be sudo in docker, but otherwise want git clone https://github.com/lucasw/rosdep --branch disable_root_etc_ros
-RUN git clone https://github.com/ros-infrastructure/rosdep
 WORKDIR $SRC/rosdep
 RUN python3 setup.py install --prefix=$DEST --record install_manifest.txt --single-version-externally-managed
 RUN rosdep init

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -12,6 +12,7 @@ apt-get install -y libboost-filesystem-dev
 apt-get install -y libboost-program-options-dev
 apt-get install -y libboost-regex-dev
 apt-get install -y libboost-thread-dev
+apt-get install -y libfmt-dev
 apt-get install -y libgpgme-dev
 apt-get install -y libgtest-dev
 apt-get install -y liblog4cxx-dev

--- a/git_clone.sh
+++ b/git_clone.sh
@@ -8,6 +8,7 @@ WS=`pwd`/catkin_ws/src
 echo $WS
 mkdir $WS -p
 
+# TODO(lucasw) replace these git clones with vcs
 # packages that need to be cmake installed, and are ros packages in a catkin workspace
 cd $WS
 git clone https://github.com/ros/catkin

--- a/ubuntu_2204/Dockerfile
+++ b/ubuntu_2204/Dockerfile
@@ -15,13 +15,7 @@ RUN apt-get install -y apt-utils
 # apt installs
 RUN apt install -y git
 RUN apt install -y ros-*
-RUN apt install -y catkin-lint cython3 libapriltag-dev libceres-dev libfrei0r-ocaml-dev
-RUN apt install -y libgeographic-dev libgmock-dev libgoogle-glog-dev libgst-dev
-RUN apt install -y libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev
-RUN apt install -y libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev
-RUN apt install -y libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev
-RUN apt install -y libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev
-RUN apt install -y python-is-python3 python3-tf2-geometry-msgs python3-venv vim curl jq
+RUN apt install -y catkin-lint cython3 libapriltag-dev libceres-dev libfmt-dev libfrei0r-ocaml-dev libgeographic-dev libgmock-dev libgoogle-glog-dev libgst-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev python-is-python3 python3-tf2-geometry-msgs python3-venv vim curl jq
 
 ENV DEST=/other/install
 RUN mkdir $DEST -p

--- a/ubuntu_2204/Dockerfile
+++ b/ubuntu_2204/Dockerfile
@@ -78,7 +78,7 @@ WORKDIR $WS/..
 RUN catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -Wno-deprecated
 # split these up so can take advantage of docker layers, otherwise one failure
 # means a huge rebuild
-RUN catkin build --no-status -j1 fuse_core
+# RUN catkin build --no-status -j1 fuse_core
 # disabling this because it is too slow to build
 # RUN catkin build --no-status -j1 rtabmap_ros
 RUN catkin build --no-status -j1 jsk_rviz_plugins
@@ -87,7 +87,7 @@ RUN catkin build --no-status -j1 plotjuggler
 RUN catkin build --no-status -j1 rqt
 RUN catkin build --no-status -j1 octomap_server
 RUN catkin build --no-status -j1 libuvc_camera
-RUN catkin build --no-status -j1 fuse_constraints
+# RUN catkin build --no-status -j1 fuse_constraints
 RUN catkin build --no-status -j1 people_tracking_filter
 RUN catkin build --no-status -j1 laser_assembler
 RUN catkin build --no-status -j1 catkin_virtualenv

--- a/ubuntu_2204/README.md
+++ b/ubuntu_2204/README.md
@@ -23,7 +23,7 @@ git clone git@github.com:lucasw/ros_from_src --branch robot_state_publisher
 ```
 
 ```
-export DEST=$HOME/catkin_ws/other/install
+export DEST=$HOME/other/install
 export PATH=$PATH:$DEST/bin
 ```
 

--- a/ubuntu_2204/README.md
+++ b/ubuntu_2204/README.md
@@ -80,8 +80,9 @@ TODO(lucasw) see if rosdep install works
 
 ---
 
+Optional
 
-Run the above in docker:
+Run the above in docker instead:
 ```
 cd ros_from_src/ubuntu_2204
 docker build . -t ros_debian_2204

--- a/ubuntu_2204/README.md
+++ b/ubuntu_2204/README.md
@@ -2,7 +2,7 @@ Install many ros packages and dependencies of ros packages that will be built fr
 
 
 ```
-sudo apt install ros-* catkin-lint cython3 libapriltag-dev libceres-dev libfrei0r-ocaml-dev libgeographic-dev libgmock-dev libgoogle-glog-dev libgst-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev python-is-python3 python3-setuptools python3-tf2-geometry-msgs python3-venv vim curl git jq
+sudo apt install ros-* catkin-lint cython3 libapriltag-dev libceres-dev libfrei0r-ocaml-dev libgeographic-dev libgeographiclib-dev libgmock-dev libgoogle-glog-dev libgst-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev python-is-python3 python3-setuptools python3-tf2-geometry-msgs python3-venv vim curl git jq
 ```
 
 Put this into ~/.bashrc so that vcs and catkin_tools can be found (TODO(lucasw) make them install to ~/.local/... instead like pip user installs?)

--- a/ubuntu_2204/README.md
+++ b/ubuntu_2204/README.md
@@ -19,7 +19,7 @@ export PYTHONPATH=$DEST/lib/python$PYTHON_MAJOR_VERSION.$PYTHON_MINOR_VERSION/si
 ```
 mkdir -p ~/other/src
 cd ~/other/src
-git clone git@github.com:lucasw/ros_from_src
+git clone git@github.com:lucasw/ros_from_src --branch robot_state_publisher
 ```
 
 ```

--- a/ubuntu_2204/README.md
+++ b/ubuntu_2204/README.md
@@ -2,7 +2,9 @@ Install many ros packages and dependencies of ros packages that will be built fr
 
 
 ```
-sudo apt install ros-* catkin-lint cython3 libapriltag-dev libceres-dev libfmt-dev libfrei0r-ocaml-dev libgeographic-dev libgeographiclib-dev libgmock-dev libgoogle-glog-dev libgst-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev python-is-python3 python3-setuptools python3-tf2-geometry-msgs python3-venv vim curl git jq
+sudo apt install ros-* catkin-lint cython3 libapriltag-dev libceres-dev libfmt-dev libfrei0r-ocaml-dev libgeographic-dev libgmock-dev libgoogle-glog-dev libgst-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev python-is-python3 python3-setuptools python3-tf2-geometry-msgs python3-venv vim curl git jq
+# 23.04 only:
+# sudo apt install libgeographiclib-dev
 ```
 
 Put this into ~/.bashrc so that vcs and catkin_tools can be found (TODO(lucasw) make them install to ~/.local/... instead like pip user installs?)

--- a/ubuntu_2204/README.md
+++ b/ubuntu_2204/README.md
@@ -2,7 +2,7 @@ Install many ros packages and dependencies of ros packages that will be built fr
 
 
 ```
-sudo apt install ros-* catkin-lint cython3 libapriltag-dev libceres-dev libfrei0r-ocaml-dev libgeographic-dev libgeographiclib-dev libgmock-dev libgoogle-glog-dev libgst-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev python-is-python3 python3-setuptools python3-tf2-geometry-msgs python3-venv vim curl git jq
+sudo apt install ros-* catkin-lint cython3 libapriltag-dev libceres-dev libfmt-dev libfrei0r-ocaml-dev libgeographic-dev libgeographiclib-dev libgmock-dev libgoogle-glog-dev libgst-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev python-is-python3 python3-setuptools python3-tf2-geometry-msgs python3-venv vim curl git jq
 ```
 
 Put this into ~/.bashrc so that vcs and catkin_tools can be found (TODO(lucasw) make them install to ~/.local/... instead like pip user installs?)

--- a/ubuntu_2204/README.md
+++ b/ubuntu_2204/README.md
@@ -2,7 +2,7 @@ Install many ros packages and dependencies of ros packages that will be built fr
 
 
 ```
-sudo apt install ros-* catkin-lint cython3 libapriltag-dev libceres-dev libfrei0r-ocaml-dev libgeographic-dev libgmock-dev libgoogle-glog-dev libgst-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev python-is-python3 python3-tf2-geometry-msgs python3-venv vim curl jq
+sudo apt install ros-* catkin-lint cython3 libapriltag-dev libceres-dev libfrei0r-ocaml-dev libgeographic-dev libgmock-dev libgoogle-glog-dev libgst-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libimage-view-dev liborocos-bfl-dev libpcl-ros-dev libqt5svg5-dev libqt5websockets5-dev libqt5x11extras5-dev libqwt-qt5-dev libsdl-image1.2-dev libspnav-dev liburdfdom-dev libuvc-dev libv4l-dev libyaml-cpp-dev python-is-python3 python3-setuptools python3-tf2-geometry-msgs python3-venv vim curl git jq
 ```
 
 Put this into ~/.bashrc so that vcs and catkin_tools can be found (TODO(lucasw) make them install to ~/.local/... instead like pip user installs?)

--- a/ubuntu_2204/README.md
+++ b/ubuntu_2204/README.md
@@ -33,7 +33,8 @@ vcs is very useful for managing a large set of git repos:
 
 ```
 cd ~/other/src
-git clone git@github.com:dirk-thomas/vcstool.git
+# git clone git@github.com:dirk-thomas/vcstool.git
+git clone https://github.com/dirk-thomas/vcstool.git
 cd vcstool
 python3 setup.py install --prefix=$DEST --record install_manifest.txt --single-version-externally-managed
 ```
@@ -41,7 +42,8 @@ python3 setup.py install --prefix=$DEST --record install_manifest.txt --single-v
 osrf_pycommon is a dependency of catkin_tools
 ```
 cd ~/other/src
-git clone git@github.com:osrf/osrf_pycommon
+# git clone git@github.com:osrf/osrf_pycommon
+git clone https://github.com/osrf/osrf_pycommon
 cd osrf_pycommon
 python3 setup.py install --prefix=$DEST --record install_manifest.txt --single-version-externally-managed
 ```
@@ -49,7 +51,8 @@ python3 setup.py install --prefix=$DEST --record install_manifest.txt --single-v
 catkin_tools is needed to catkin build (but if catkin_make is preferred then this and osrf_pycommon isn't necessary)
 ```
 cd ~/other/src
-git clone git@github.com:lucasw/catkin_tools --branch sanitize_cmake_prefix_path
+# git clone git@github.com:lucasw/catkin_tools --branch sanitize_cmake_prefix_path
+git clone https:github.com/lucasw/catkin_tools --branch sanitize_cmake_prefix_path
 cd catkin_tools
 python3 setup.py install --prefix=$DEST --record install_manifest.txt --single-version-externally-managed
 ```
@@ -60,6 +63,10 @@ Download a bunch of repos that are not available in 22.04 through apt, some with
 mkdir -p ~/base_catkin_ws/src
 cd ~/base_catkin_ws/src
 ln -s ~/other/src/ros_from_src/ubuntu_2204/base_repos.yaml
+
+# optional step needed if can't do git clone git@github... on this system
+sed -i 's/git@github.com:/https:\/\/github.com\//' base_repos.yaml
+
 vcs import --shallow < base_repos.yaml
 # ignore repos that aren't yet building in 22.04
 ~/other/src/ros_from_src/ubuntu_2204/ignore.sh

--- a/ubuntu_2204/base_repos.yaml
+++ b/ubuntu_2204/base_repos.yaml
@@ -126,7 +126,7 @@ repositories:
   other/PlotJuggler:
     type: git
     url: git@github.com:facontidavide/PlotJuggler.git
-    version: 01a86f8aa0a6b960832012c1810cea34642c7268
+    version: main
   other/anybotics/elevation_mapping:
     type: git
     url: git@github.com:ANYbotics/elevation_mapping.git

--- a/ubuntu_2204/base_repos.yaml
+++ b/ubuntu_2204/base_repos.yaml
@@ -389,8 +389,8 @@ repositories:
     version: cpp17
   ros/laser_assembler:
     type: git
-    url: git@github.com:lucasw/laser_assembler
-    version: boost_placeholders
+    url: git@github.com:ros-o/laser_assembler
+    version: obese-devel
   ros/libuvc_ros:
     type: git
     url: git@github.com:lucasw/libuvc_ros.git
@@ -401,8 +401,8 @@ repositories:
     version: kinetic-devel
   ros/navigation:
     type: git
-    url: git@github.com:lucasw/navigation
-    version: boost_placeholders
+    url: git@github.com:ros-planning/navigation
+    version: noetic-devel
   ros/nmea_msgs:
     type: git
     url: git@github.com:ros-drivers/nmea_msgs

--- a/ubuntu_2204/base_repos.yaml
+++ b/ubuntu_2204/base_repos.yaml
@@ -425,7 +425,7 @@ repositories:
     type: git
     url: git@github.com:lucasw/robot_state_publisher
     version: robot_state_function
-  ros_comm:
+  ros/ros_comm:
     type: git
     url: git@github.com:lucasw/ros_comm
     version: salsa_noetic_aggregated
@@ -441,7 +441,7 @@ repositories:
     type: git
     url: git@github.com:lucasw/ros_tutorials.git
     version: boost_placeholders
-  rosconsole:
+  ros/rosconsole:
     type: git
     url: git@github.com:lucasw/rosconsole
     version: concise_output_roso

--- a/ubuntu_2204/base_repos.yaml
+++ b/ubuntu_2204/base_repos.yaml
@@ -406,7 +406,7 @@ repositories:
   ros/grid_map:
     type: git
     url: git@github.com:lucasw/grid_map
-    version: cpp17
+    version: tbb_2021
   ros/image_common:
     type: git
     url: git@github.com:lucasw/image_common

--- a/ubuntu_2204/base_repos.yaml
+++ b/ubuntu_2204/base_repos.yaml
@@ -459,7 +459,7 @@ repositories:
     version: salsa
   ros/rqt:
     type: git
-    url: git@github.com:ros-visualization/rqt.git
+    url: git@github.com:lucasw/rqt.git
     version: kinetic-devel
   ros/rqt_console:
     type: git

--- a/ubuntu_2204/base_repos.yaml
+++ b/ubuntu_2204/base_repos.yaml
@@ -42,7 +42,7 @@ repositories:
   lucasw/image_manip:
     type: git
     url: git@github.com:lucasw/image_manip
-    version: master
+    version: fix_zero_frame_rate
   lucasw/joy_feedback_ros:
     type: git
     url: git@github.com:lucasw/joy_feedback_ros
@@ -163,6 +163,10 @@ repositories:
     type: git
     url: git@github.com:ros-o/ddynamic_reconfigure
     version: obese-devel
+  other/depthai-ros-examples:
+    type: git
+    url: git@github.com:luxonis/depthai-ros-examples.git
+    version: main
   other/euslisp-release:
     type: git
     url: git@github.com:tork-a/euslisp-release.git
@@ -186,7 +190,7 @@ repositories:
   other/fuse:
     type: git
     url: git@github.com:lucasw/fuse
-    version: lucasw_test_cpp17
+    version: cpp17
   other/geneus:
     type: git
     url: git@github.com:jsk-ros-pkg/geneus.git
@@ -202,7 +206,7 @@ repositories:
   other/jsk_common:
     type: git
     url: git@github.com:lucasw/jsk_common
-    version: pluginlib_hpp
+    version: video_to_bag_features
   other/jsk_common_msgs:
     type: git
     url: git@github.com:lucasw/jsk_common_msgs
@@ -219,6 +223,14 @@ repositories:
     type: git
     url: git@github.com:lucasw/jsk_visualization
     version: boost_placeholders
+  other/libnabo:
+    type: git
+    url: git@github.com:ethz-asl/libnabo
+    version: master
+  other/lvr2:
+    type: git
+    url: git@github.com:lucasw/lvr2
+    version: build_2304
   other/marti_messages:
     type: git
     url: git@github.com:swri-robotics/marti_messages.git
@@ -226,7 +238,15 @@ repositories:
   other/mavros:
     type: git
     url: git@github.com:lucasw/mavros
-    version: pluginlib_hpp
+    version: master
+  other/mesh_tools:
+    type: git
+    url: git@github.com:lucasw/mesh_tools
+    version: generate_mesh_geometry
+  other/message_filters:
+    type: git
+    url: git@github.com:fkie/message_filters.git
+    version: master
   other/nmea_navsat_driver:
     type: git
     url: git@github.com:ros-drivers/nmea_navsat_driver.git
@@ -238,7 +258,7 @@ repositories:
   other/octomap_mapping:
     type: git
     url: git@github.com:lucasw/octomap_mapping.git
-    version: pluginlib_hpp
+    version: filter_limits
   other/octomap_ros:
     type: git
     url: git@github.com:lucasw/octomap_ros
@@ -247,6 +267,10 @@ repositories:
     type: git
     url: git@github.com:lucasw/openni2_camera.git
     version: subprocess_wtf_python3_7
+  other/pal_statistics:
+    type: git
+    url: git@github.com:pal-robotics/pal_statistics.git
+    version: kinetic-devel
   other/people:
     type: git
     url: git@github.com:wg-perception/people.git
@@ -257,8 +281,8 @@ repositories:
     version: boost_placeholders
   other/plotjuggler-ros-plugins:
     type: git
-    url: git@github.com:PlotJuggler/plotjuggler-ros-plugins.git
-    version: development
+    url: git@github.com:lucasw/plotjuggler-ros-plugins
+    version: depend_pal_statistics_msgs
   other/plotjuggler_msgs:
     type: git
     url: git@github.com:PlotJuggler/plotjuggler_msgs.git
@@ -275,18 +299,30 @@ repositories:
     type: git
     url: git@github.com:lucasw/ros_rtsp
     version: pluginlib_hpp
+  other/rosbag_snapshot:
+    type: git
+    url: git@github.com:ros/rosbag_snapshot.git
+    version: main
   other/rosboard:
     type: git
     url: git@github.com:dheera/rosboard.git
     version: main
+  other/rosfmt:
+    type: git
+    url: git@github.com:lucasw/rosfmt
+    version: build_2204
+  other/rosmon:
+    type: git
+    url: git@github.com:lucasw/rosmon
+    version: build_2204
   other/rosshow:
     type: git
     url: git@github.com:dheera/rosshow
     version: main
   other/rqt_ez_publisher:
     type: git
-    url: git@github.com:OTL/rqt_ez_publisher.git
-    version: melodic-devel
+    url: git@github.com:lucasw/rqt_ez_publisher
+    version: ubuntu2210
   other/rtabmap:
     type: git
     url: git@github.com:introlab/rtabmap.git
@@ -294,7 +330,11 @@ repositories:
   other/rtabmap_ros:
     type: git
     url: git@github.com:lucasw/rtabmap_ros
-    version: pluginlib_hpp
+    version: build_rtabmap_viz
+  other/static_transform_mux:
+    type: git
+    url: git@github.com:tradr-project/static_transform_mux.git
+    version: master
   other/tf2_2d:
     type: git
     url: git@github.com:locusrobotics/tf2_2d.git
@@ -386,11 +426,11 @@ repositories:
   ros/joystick_drivers:
     type: git
     url: git@github.com:lucasw/joystick_drivers
-    version: cpp17
+    version: warn_not_error_if_no_joy
   ros/laser_assembler:
     type: git
-    url: git@github.com:ros-o/laser_assembler
-    version: obese-devel
+    url: git@github.com:lucasw/laser_assembler
+    version: noetic-devel
   ros/libuvc_ros:
     type: git
     url: git@github.com:lucasw/libuvc_ros.git
@@ -401,8 +441,8 @@ repositories:
     version: kinetic-devel
   ros/navigation:
     type: git
-    url: git@github.com:ros-planning/navigation
-    version: noetic-devel
+    url: git@github.com:lucasw/navigation
+    version: lucasw_debug
   ros/nmea_msgs:
     type: git
     url: git@github.com:ros-drivers/nmea_msgs
@@ -507,6 +547,14 @@ repositories:
     type: git
     url: git@github.com:ros-teleop/teleop_twist_keyboard.git
     version: master
+  ros/twist_mux:
+    type: git
+    url: git@github.com:lucasw/twist_mux
+    version: ubuntu2210
+  ros/twist_mux_msgs:
+    type: git
+    url: git@github.com:ros-teleop/twist_mux_msgs
+    version: melodic-devel
   ros/unique_identifier:
     type: git
     url: git@github.com:ros-geographic-info/unique_identifier.git
@@ -558,4 +606,4 @@ repositories:
   roso/rqt_image_view:
     type: git
     url: git@github.com:lucasw/rqt_image_view
-    version: obese-devel
+    version: detection2d_image_view

--- a/ubuntu_2204/base_repos.yaml
+++ b/ubuntu_2204/base_repos.yaml
@@ -459,6 +459,10 @@ repositories:
     type: git
     url: git@github.com:lucasw/rqt
     version: ubuntu_2210
+  ros/rqt_bag:
+    type: git
+    url: git@github.com:lucasw/rqt_bag
+    version: build_2204
   ros/rqt_console:
     type: git
     url: git@github.com:ros-visualization/rqt_console.git
@@ -479,6 +483,10 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/rqt_reconfigure
     version: master
+  ros/rqt_robot_monitor:
+    type: git
+    url: git@github.com:ros-visualization/rqt_robot_monitor.git
+    version: ros1
   ros/rqt_robot_steering:
     type: git
     url: git@github.com:lucasw/rqt_robot_steering.git

--- a/ubuntu_2204/base_repos.yaml
+++ b/ubuntu_2204/base_repos.yaml
@@ -6,11 +6,11 @@ repositories:
   clearpath/husky:
     type: git
     url: git@github.com:lucasw/husky
-    version: cpp17
+    version: roslint_fixes
   clearpath/moose:
     type: git
-    url: git@github.com:moose-cpr/moose.git
-    version: master
+    url: git@github.com:lucasw/moose
+    version: pluginlib_hpp
   clearpath/moose_simulator:
     type: git
     url: git@github.com:moose-cpr/moose_simulator.git
@@ -139,6 +139,10 @@ repositories:
     type: git
     url: git@github.com:lucasw/kindr_ros
     version: cpp17
+  other/anybotics/message_logger:
+    type: git
+    url: git@github.com:lucasw/message_logger
+    version: line_endings
   other/anybotics/point_cloud_io:
     type: git
     url: git@github.com:ANYbotics/point_cloud_io
@@ -159,10 +163,6 @@ repositories:
     type: git
     url: git@github.com:ros-o/ddynamic_reconfigure
     version: obese-devel
-  other/depthai-ros-examples:
-    type: git
-    url: git@github.com:luxonis/depthai-ros-examples.git
-    version: main
   other/euslisp-release:
     type: git
     url: git@github.com:tork-a/euslisp-release.git
@@ -177,8 +177,8 @@ repositories:
     version: master
   other/fiducials:
     type: git
-    url: git@github.com:lucasw/fiducials.git
-    version: boost_placeholders
+    url: git@github.com:lucasw/fiducials
+    version: cmake_vision_msgs
   other/find-object:
     type: git
     url: git@github.com:lucasw/find-object.git
@@ -194,7 +194,7 @@ repositories:
   other/graph_rviz_plugin:
     type: git
     url: git@github.com:lucasw/graph_rviz_plugin
-    version: cpp17
+    version: pluginlib_hpp
   other/hector_slam:
     type: git
     url: git@github.com:lucasw/hector_slam
@@ -202,7 +202,7 @@ repositories:
   other/jsk_common:
     type: git
     url: git@github.com:lucasw/jsk_common
-    version: cpp17
+    version: pluginlib_hpp
   other/jsk_common_msgs:
     type: git
     url: git@github.com:lucasw/jsk_common_msgs
@@ -225,20 +225,20 @@ repositories:
     version: master
   other/mavros:
     type: git
-    url: git@github.com:mavlink/mavros.git
-    version: master
+    url: git@github.com:lucasw/mavros
+    version: pluginlib_hpp
   other/nmea_navsat_driver:
     type: git
     url: git@github.com:ros-drivers/nmea_navsat_driver.git
     version: master
   other/nodelet_rosbag:
     type: git
-    url: git@github.com:oriondream/nodelet_rosbag.git
-    version: in_place_factory
+    url: git@github.com:lucasw/nodelet_rosbag
+    version: pluginlib_hpp
   other/octomap_mapping:
     type: git
     url: git@github.com:lucasw/octomap_mapping.git
-    version: kinetic-devel
+    version: pluginlib_hpp
   other/octomap_ros:
     type: git
     url: git@github.com:lucasw/octomap_ros
@@ -271,6 +271,10 @@ repositories:
     type: git
     url: git@github.com:lucasw/ros_numpy.git
     version: collections_abc
+  other/ros_rtsp:
+    type: git
+    url: git@github.com:lucasw/ros_rtsp
+    version: pluginlib_hpp
   other/rosboard:
     type: git
     url: git@github.com:dheera/rosboard.git
@@ -289,10 +293,8 @@ repositories:
     version: master
   other/rtabmap_ros:
     type: git
-    url: git@github.com:introlab/rtabmap_ros
-    version: master
-    # url: git@github.com:lucasw/rtabmap_ros
-    # version: remove_qt5_use_modules
+    url: git@github.com:lucasw/rtabmap_ros
+    version: pluginlib_hpp
   other/tf2_2d:
     type: git
     url: git@github.com:locusrobotics/tf2_2d.git
@@ -368,7 +370,7 @@ repositories:
   ros/image_common:
     type: git
     url: git@github.com:lucasw/image_common
-    version: noetic-devel
+    version: ubuntu_2210
   ros/image_pipeline:
     type: git
     url: git@github.com:lucasw/image_pipeline
@@ -409,10 +411,10 @@ repositories:
     type: git
     url: git@github.com:OctoMap/octomap_msgs.git
     version: melodic-devel
-  # ros/pluginlib:
-  #   type: git
-  #   url: git@github.com:lucasw/pluginlib
-  #   version: cpp17_test
+  ros/pluginlib:
+    type: git
+    url: git@github.com:lucasw/pluginlib
+    version: cpp17_test
   ros/realtime_tools:
     type: git
     url: git@github.com:ros-controls/realtime_tools.git
@@ -444,7 +446,7 @@ repositories:
   ros/rosconsole:
     type: git
     url: git@github.com:lucasw/rosconsole
-    version: concise_output_roso
+    version: ubuntu_2210
   ros/roscpp_core:
     type: git
     url: git@github.com:lucasw/roscpp_core
@@ -459,8 +461,8 @@ repositories:
     version: salsa
   ros/rqt:
     type: git
-    url: git@github.com:lucasw/rqt.git
-    version: kinetic-devel
+    url: git@github.com:lucasw/rqt
+    version: ubuntu_2210
   ros/rqt_console:
     type: git
     url: git@github.com:ros-visualization/rqt_console.git
@@ -481,14 +483,14 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/rqt_reconfigure
     version: master
-  ros/rqt_robot_monitor:
-    type: git
-    url: git@github.com:ros-visualization/rqt_robot_monitor.git
-    version: ros1
   ros/rqt_robot_steering:
     type: git
     url: git@github.com:lucasw/rqt_robot_steering.git
     version: python310
+  ros/rqt_tf_tree:
+    type: git
+    url: git@github.com:ros-visualization/rqt_tf_tree.git
+    version: master
   ros/rviz:
     type: git
     url: git@github.com:lucasw/rviz.git
@@ -517,6 +519,10 @@ repositories:
     type: git
     url: git@github.com:ros-drivers/usb_cam.git
     version: develop
+  ros/video_stream_opencv:
+    type: git
+    url: git@github.com:lucasw/video_stream_opencv
+    version: build_2204
   ros/view_controller_msgs:
     type: git
     url: git@github.com:ros-visualization/view_controller_msgs.git
@@ -531,7 +537,7 @@ repositories:
     version: boost_placeholders
   ros/xacro:
     type: git
-    url: git@github.com:lucasw/xacro
+    url: git@github.com:lucasw/xacro.git
     version: cleanup_roslint
   roso/control_toolbox:
     type: git
@@ -539,13 +545,13 @@ repositories:
     version: obese-devel
   roso/qt_gui_core:
     type: git
-    url: https://github.com/ros-o/qt_gui_core
-    version: obese-devel
+    url: git@github.com:lucasw/qt_gui_core
+    version: ubuntu_2210
   roso/rosparam_shortcuts:
     type: git
     url: git@github.com:lucasw/rosparam_shortcuts
     version: cleanup_lint
   roso/rqt_image_view:
     type: git
-    url: git@github.com:ros-o/rqt_image_view.git
-    version: obese-devel
+    url: git@github.com:lucasw/rqt_image_view
+    version: ubuntu_2210

--- a/ubuntu_2204/base_repos.yaml
+++ b/ubuntu_2204/base_repos.yaml
@@ -411,10 +411,6 @@ repositories:
     type: git
     url: git@github.com:OctoMap/octomap_msgs.git
     version: melodic-devel
-  ros/pluginlib:
-    type: git
-    url: git@github.com:lucasw/pluginlib
-    version: cpp17_test
   ros/realtime_tools:
     type: git
     url: git@github.com:ros-controls/realtime_tools.git
@@ -554,4 +550,4 @@ repositories:
   roso/rqt_image_view:
     type: git
     url: git@github.com:lucasw/rqt_image_view
-    version: ubuntu_2210
+    version: obese-devel

--- a/ubuntu_2204/base_repos.yaml
+++ b/ubuntu_2204/base_repos.yaml
@@ -421,6 +421,10 @@ repositories:
     type: git
     url: git@github.com:lucasw/robot_localization
     version: boost_placeholders_cpp17
+  ros/robot_state_publisher:
+    type: git
+    url: git@github.com:lucasw/robot_state_publisher
+    version: robot_state_function
   ros_comm:
     type: git
     url: git@github.com:lucasw/ros_comm

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -1,7 +1,4 @@
 #!/bin/sh
-# These build fine in 22.04 but take too long to build in github actions
-touch ./other/rtabmap/CATKIN_IGNORE
-touch ./other/rtabmap_ros/CATKIN_IGNORE
 # These are ignored because they don't yet build in 22.04, need modifications,
 # or depend on gazebo
 touch ./clearpath/husky/husky_gazebo/CATKIN_IGNORE

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -10,6 +10,7 @@ touch ./other/catkin_virtualenv/test_catkin_virtualenv/CATKIN_IGNORE
 touch ./other/catkin_virtualenv/test_catkin_virtualenv_python2/CATKIN_IGNORE
 touch ./other/depthai-ros-examples/CATKIN_IGNORE
 touch ./other/fiducials/aruco_gazebo/CATKIN_IGNORE
+touch ./other/jsk_common/jsk_rosbag_tools/CATKIN_IGNORE
 touch ./other/jsk_recognition/imagesift/CATKIN_IGNORE
 touch ./other/jsk_recognition/jsk_libfreenect2/CATKIN_IGNORE
 touch ./other/jsk_recognition/jsk_pcl_ros/CATKIN_IGNORE

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -31,3 +31,4 @@ touch ./ros/grid_map/grid_map_demos/CATKIN_IGNORE
 touch ./ros/grid_map/grid_map_filters/CATKIN_IGNORE
 touch ./ros/joystick_drivers/ps3joy/CATKIN_IGNORE
 touch ./ros/joystick_drivers/wiimote/CATKIN_IGNORE
+touch ./ros/web_video_server/CATKIN_IGNORE

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -10,6 +10,8 @@ touch ./other/anybotics/elevation_mapping/CATKIN_IGNORE
 touch ./other/catkin_virtualenv/test_catkin_virtualenv/CATKIN_IGNORE
 # touch ./other/catkin_virtualenv/test_catkin_virtualenv_python2/CATKIN_IGNORE
 touch ./other/depthai-ros-examples/CATKIN_IGNORE
+touch ./other/ffmpeg_image_transport/CATKIN_IGNORE
+touch ./other/ffmpeg_image_transport_msgs/CATKIN_IGNORE
 touch ./other/fiducials/aruco_gazebo/CATKIN_IGNORE
 touch ./other/jsk_common/jsk_rosbag_tools/CATKIN_IGNORE
 touch ./other/jsk_recognition/imagesift/CATKIN_IGNORE

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -22,6 +22,7 @@ touch ./other/jsk_recognition/jsk_perception/CATKIN_IGNORE
 touch ./other/jsk_recognition/sound_classification/CATKIN_IGNORE
 touch ./other/jsk_roseus/CATKIN_IGNORE
 touch ./other/jsk_roseus/roseus_msgs/CATKIN_IGNORE
+touch ./other/euslisp-release/CATKIN_IGNORE
 touch ./other/geneus/CATKIN_IGNORE
 touch ./other/lvr2/CATKIN_IGNORE
 touch ./other/mesh_tools/CATKIN_IGNORE

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -19,6 +19,8 @@ touch ./other/jsk_recognition/jsk_perception/CATKIN_IGNORE
 touch ./other/jsk_recognition/sound_classification/CATKIN_IGNORE
 touch ./other/jsk_roseus/CATKIN_IGNORE
 touch ./other/jsk_roseus/roseus_msgs/CATKIN_IGNORE
+touch ./other/lvr2/CATKIN_IGNORE
+touch ./other/mesh_tools/CATKIN_IGNORE
 touch ./other/mavros/CATKIN_IGNORE
 touch ./other/openni2_camera/CATKIN_IGNORE
 touch ./other/people/face_detector/CATKIN_IGNORE

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -8,7 +8,7 @@ touch ./clearpath/warthog_simulator/CATKIN_IGNORE
 touch ./greenzie/boustrophedon_planner/CATKIN_IGNORE
 touch ./other/anybotics/elevation_mapping/CATKIN_IGNORE
 touch ./other/catkin_virtualenv/test_catkin_virtualenv/CATKIN_IGNORE
-touch ./other/catkin_virtualenv/test_catkin_virtualenv_python2/CATKIN_IGNORE
+# touch ./other/catkin_virtualenv/test_catkin_virtualenv_python2/CATKIN_IGNORE
 touch ./other/depthai-ros-examples/CATKIN_IGNORE
 touch ./other/fiducials/aruco_gazebo/CATKIN_IGNORE
 touch ./other/jsk_common/jsk_rosbag_tools/CATKIN_IGNORE

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -22,6 +22,7 @@ touch ./other/mavros/CATKIN_IGNORE
 touch ./other/openni2_camera/CATKIN_IGNORE
 touch ./other/people/face_detector/CATKIN_IGNORE
 touch ./other/people/leg_detector/CATKIN_IGNORE
+touch ./other/ros_rtsp/CATKIN_IGNORE
 touch ./ros/gazebo_ros_demos/CATKIN_IGNORE
 touch ./ros/gazebo_ros_pkgs/CATKIN_IGNORE
 touch ./ros/grid_map/grid_map_demos/CATKIN_IGNORE

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # These are ignored because they don't yet build in 22.04, need modifications,
 # or depend on gazebo
+touch ./clearpath/CATKIN_IGNORE
 touch ./clearpath/husky/husky_gazebo/CATKIN_IGNORE
 touch ./clearpath/moose_simulator/CATKIN_IGNORE
 touch ./clearpath/warthog_simulator/CATKIN_IGNORE

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -29,6 +29,7 @@ touch ./other/openni2_camera/CATKIN_IGNORE
 touch ./other/people/face_detector/CATKIN_IGNORE
 touch ./other/people/leg_detector/CATKIN_IGNORE
 touch ./other/ros_rtsp/CATKIN_IGNORE
+touch ./other/pal_statistics/pal_statistics/CATKIN_IGNORE
 touch ./ros/gazebo_ros_demos/CATKIN_IGNORE
 touch ./ros/gazebo_ros_pkgs/CATKIN_IGNORE
 touch ./ros/grid_map/grid_map_demos/CATKIN_IGNORE

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -18,10 +18,7 @@ touch ./other/jsk_recognition/jsk_perception/CATKIN_IGNORE
 touch ./other/jsk_recognition/sound_classification/CATKIN_IGNORE
 touch ./other/jsk_roseus/CATKIN_IGNORE
 touch ./other/jsk_roseus/roseus_msgs/CATKIN_IGNORE
-touch ./other/mavros/libmavconn/CATKIN_IGNORE
-touch ./other/mavros/mavros/CATKIN_IGNORE
-touch ./other/mavros/mavros_extras/CATKIN_IGNORE
-touch ./other/mavros/test_mavros/CATKIN_IGNORE
+touch ./other/mavros/CATKIN_IGNORE
 touch ./other/openni2_camera/CATKIN_IGNORE
 touch ./other/people/face_detector/CATKIN_IGNORE
 touch ./other/people/leg_detector/CATKIN_IGNORE

--- a/ubuntu_2204/ignore.sh
+++ b/ubuntu_2204/ignore.sh
@@ -22,6 +22,7 @@ touch ./other/jsk_recognition/jsk_perception/CATKIN_IGNORE
 touch ./other/jsk_recognition/sound_classification/CATKIN_IGNORE
 touch ./other/jsk_roseus/CATKIN_IGNORE
 touch ./other/jsk_roseus/roseus_msgs/CATKIN_IGNORE
+touch ./other/geneus/CATKIN_IGNORE
 touch ./other/lvr2/CATKIN_IGNORE
 touch ./other/mesh_tools/CATKIN_IGNORE
 touch ./other/mavros/CATKIN_IGNORE


### PR DESCRIPTION
Add some new repos and ignore a few old ones, larger ones are a custom robot_state_publisher and rqt_image_view (should be backwards compatible, just have some new features).

Fix and update ubuntu_2204 README.

Build install and devel separately in github action matrix to speed up build, reuse most of the yaml.

Need libfmt-dev.

